### PR TITLE
Fix bug that stopped this package from working

### DIFF
--- a/lib/markdown-preview-opener.coffee
+++ b/lib/markdown-preview-opener.coffee
@@ -24,7 +24,7 @@ module.exports = MarkdownPreviewOpener =
     if suffix in atom.config.get('markdown-preview-opener.suffixes')
       previewUrl = "markdown-preview://editor/#{event.item.id}"
       previewPane = atom.workspace.paneForURI(previewUrl)
-      workspaceView = atom.views.getView(atom.workspace)
+      workspaceView = event.item.component.element
       if not previewPane
         atom.commands.dispatch workspaceView, 'markdown-preview:toggle'
         if atom.config.get('markdown-preview-opener.closePreviewWhenClosingEditor')


### PR DESCRIPTION
For some reason the previous method of opening the preview pane didn't work anymore. This method dispatches the event on the editor instead of the workspace.